### PR TITLE
version 2.0.4 : le champ viarss est pris en charge par seenthis (core)

### DIFF
--- a/base/seenthis_importer_flux.php
+++ b/base/seenthis_importer_flux.php
@@ -28,11 +28,3 @@ function seenthis_importer_flux_declarer_champs_extras($champs = array()) {
 
 	return $champs;
 }
-
-function seenthis_importer_flux_declarer_tables_principales($tables_principales) {
-
-	$me = &$tables_principales['spip_auteurs'];
-	$me['field']['viarss'] = "tinyint(1) NOT NULL DEFAULT '0'";
-	
-	return $tables_principales;
-}

--- a/paquet.xml
+++ b/paquet.xml
@@ -1,7 +1,7 @@
 <paquet
 	prefix="seenthis_importer_flux"
 	categorie="outil"
-	version="2.0.3"
+	version="2.0.4"
 	etat="stable"
 	compatibilite="[3.0.0;3.2.*]"
 	schema="1.0.1"

--- a/seenthis_importer_flux_administrations.php
+++ b/seenthis_importer_flux_administrations.php
@@ -9,16 +9,7 @@ include_spip('inc/meta');
 function seenthis_importer_flux_upgrade($nom_meta_base_version,$version_cible){
 	$maj = array();
 
-	$maj['create'] = array(
-		array('sql_alter',"TABLE spip_me ADD viarss tinyint(1) NOT NULL DEFAULT '0'")
-	);
-
 	cextras_api_upgrade(seenthis_importer_flux_declarer_champs_extras(), $maj['create']);
-
-	// en 1.0.1, poser viarss=0
-	$maj['1.0.1'] = array(
-		array('sql_alter',"TABLE spip_me ADD viarss tinyint(1) NOT NULL DEFAULT '0'"),
-	);
 
 	include_spip('base/upgrade');
 	maj_plugin($nom_meta_base_version, $version_cible, $maj);


### PR DESCRIPTION
retour sur #7 & ref https://github.com/seenthis/seenthis_squelettes/issues/177